### PR TITLE
[Fix]: Fix workflow docker-build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,10 +2,14 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
+    branches:
+      - 'main'
+      - '!develop'
+    tags:
+      - v?.?.?
   pull_request:
-    branches: [ main ]
+    branches:
+      - 'main'
 
 env:
   REGISTRY: ghcr.io
@@ -16,8 +20,11 @@ jobs:
     outputs:
       dockerfiles: ${{ steps.set-dockerfiles.outputs.dockerfiles }}
     steps:
-      - uses: actions/checkout@v4
-      - id: set-dockerfiles
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set Dockerfiles
+        id: set-dockerfiles
         run: |
           DOCKERFILES=$(find . -name "Dockerfile" | jq -R -s -c 'split("\n")[:-1]')
           echo "dockerfiles=$DOCKERFILES" >> $GITHUB_OUTPUT
@@ -34,14 +41,15 @@ jobs:
         dockerfile: ${{ fromJson(needs.prepare.outputs.dockerfiles) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set image name
         run: |
           DOCKERFILE_PATH="${{ matrix.dockerfile }}"
           DIRECTORY=$(dirname "$DOCKERFILE_PATH")
-          IMAGE_NAME="${{ github.repository }}$(echo $DIRECTORY | sed 's/^\.//')"
-          DOCKERFILE_NAME=$(basename "$DOCKERFILE_PATH" | sed 's/Dockerfile//')
+          IMAGE_NAME="${{ github.repository }}-$(echo $DIRECTORY | sed 's/^\.\/distribution\///')"
+          DOCKERFILE_NAME=$(basename "$DOCKERFILE_PATH"')
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
           echo "DOCKERFILE_NAME=$DOCKERFILE_NAME" >> $GITHUB_ENV
 
@@ -78,12 +86,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BUILD_DATE=${{ steps.meta.outputs.created }}
+            BUILD_DATE=$(TZ=Europe/Madrid date)
             VCS_REF=${{ github.sha }}
             VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=docker,dest=/tmp/image.tar
+          outputs: type=docker,dest=/tmp/$IMAGE_NAME.tar
 
       - name: Create scan directory
         run: mkdir -p scan-results
@@ -91,7 +99,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          input: /tmp/image.tar
+          input: /tmp/$IMAGE_NAME.tar
           format: 'sarif'
           output: 'scan-results/trivy-results${{ env.DOCKERFILE_NAME }}.sarif'
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -49,7 +49,7 @@ jobs:
           DOCKERFILE_PATH="${{ matrix.dockerfile }}"
           DIRECTORY=$(dirname "$DOCKERFILE_PATH")
           IMAGE_NAME="${{ github.repository }}-$(echo $DIRECTORY | sed 's/^\.\/distribution\///')"
-          DOCKERFILE_NAME=$(basename "$DOCKERFILE_PATH"')
+          DOCKERFILE_NAME=$(basename "$DOCKERFILE_PATH")
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
           echo "DOCKERFILE_NAME=$DOCKERFILE_NAME" >> $GITHUB_ENV
 
@@ -100,10 +100,10 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           input: /tmp/$IMAGE_NAME.tar
-          format: 'sarif'
-          output: 'scan-results/trivy-results${{ env.DOCKERFILE_NAME }}.sarif'
+          format: "sarif"
+          output: "scan-results/trivy-results${{ env.DOCKERFILE_NAME }}-$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').sarif"
 
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'scan-results/trivy-results${{ env.DOCKERFILE_NAME }}.sarif'
+          sarif_file: "scan-results/trivy-results${{ env.DOCKERFILE_NAME }}-$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').sarif"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -91,7 +91,7 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=docker,dest=/tmp/$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').tar
+          outputs: type=docker,dest=/tmp/image.tar
 
       - name: Create scan directory
         run: mkdir -p scan-results
@@ -99,7 +99,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          input: /tmp/$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').tar
+          input: /tmp/image.tar
           format: "sarif"
           output: "scan-results/trivy-results${{ env.DOCKERFILE_NAME }}-$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').sarif"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -91,7 +91,7 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=docker,dest=/tmp/$IMAGE_NAME.tar
+          outputs: type=docker,dest=/tmp/$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').tar
 
       - name: Create scan directory
         run: mkdir -p scan-results
@@ -99,7 +99,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          input: /tmp/$IMAGE_NAME.tar
+          input: /tmp/$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').tar
           format: "sarif"
           output: "scan-results/trivy-results${{ env.DOCKERFILE_NAME }}-$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').sarif"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -101,9 +101,9 @@ jobs:
         with:
           input: /tmp/image.tar
           format: "sarif"
-          output: "scan-results/trivy-results${{ env.DOCKERFILE_NAME }}-$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').sarif"
+          output: "scan-results/trivy-results${{ env.DOCKERFILE_NAME }}.sarif"
 
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: "scan-results/trivy-results${{ env.DOCKERFILE_NAME }}-$(echo $DIRECTORY | sed 's/^\\.\\/distribution\\///').sarif"
+          sarif_file: "scan-results/trivy-results${{ env.DOCKERFILE_NAME }}.sarif"


### PR DESCRIPTION
This pull request makes several updates to the Docker build workflow in the `.github/workflows/docker-build.yml` file. The changes include modifying the branches and tags configuration, improving the naming conventions for steps, and updating the image naming and build arguments.

Changes to workflow configuration:

* Updated the branches and tags configuration to include the `main` branch and exclude the `develop` branch. Tags now follow the pattern `v?.?.?` instead of `v*`.

Improvements to step naming and structure:

* Renamed the steps for better clarity, such as changing `actions/checkout@v4` to `Checkout code` and `set-dockerfiles` to `Set Dockerfiles`. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L19-R27) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L37-R52)

Updates to image naming and build arguments:

* Modified the `IMAGE_NAME` and `DOCKERFILE_NAME` variables to improve the naming conventions, ensuring the image name includes the repository and directory path.
* Updated the `BUILD_DATE` argument to use the current date in the `Europe/Madrid` timezone.

Other minor adjustments:

* Changed the output destination for Docker images to include the image name in the file path.
* Updated the input path for the Trivy vulnerability scanner to use the new image name in the file path.
