### PR TITLE
[Fix]: Fix tag template in workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
       - '!develop'
     tags:
-      - v?.?.?
+      - v*
   pull_request:
     branches:
       - 'main'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docker-build.yml` file. The change modifies the tag pattern for triggering the workflow.

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L9-R9): Changed the tag pattern from `v?.?.?` to `v*` to simplify the tag matching for triggering the workflow.
