### PR TITLE
[Fix]: Fix workflow build and scan with trivy

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -124,13 +124,16 @@ jobs:
         run: |
           echo "IMAGE_NAME=${{ github.repository }}-$(basename ${{ matrix.distro }})" >> $GITHUB_ENV
 
+      - name: Create scan directory
+        run: mkdir -p scan-results
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: "image"
           image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           format: "sarif"
-          output: "trivy-results-${{ env.IMAGE_NAME }}.sarif"
+          output: "scan-results/trivy-results-$(basename ${{ matrix.distro }}).sarif"
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -138,4 +141,4 @@ jobs:
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3.27.6
         with:
-          sarif_file: "trivy-results-${{ env.IMAGE_NAME }}.sarif"
+          sarif_file: "scan-results/trivy-results-$(basename ${{ matrix.distro }}).sarif"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -124,16 +124,13 @@ jobs:
         run: |
           echo "IMAGE_NAME=${{ github.repository }}-$(basename ${{ matrix.distro }})" >> $GITHUB_ENV
 
-      - name: Create scan directory
-        run: mkdir -p scan-results
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: "image"
           image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           format: "sarif"
-          output: "scan-results/trivy-results-${{ env.IMAGE_NAME }}.sarif"
+          output: "trivy-results-${{ env.IMAGE_NAME }}.sarif"
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -141,4 +138,4 @@ jobs:
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3.27.6
         with:
-          sarif_file: "scan-results/trivy-results-${{ env.IMAGE_NAME }}.sarif"
+          sarif_file: "trivy-results-${{ env.IMAGE_NAME }}.sarif"


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build-images.yml` file to improve the naming convention of Trivy scan result files.

* [`.github/workflows/build-images.yml`](diffhunk://#diff-a6ce9b5b0a53d8dc6dbd59d40b23994c3e68a91fac73c0d7eacdf373c95476c9L136-R144): Changed the `output` and `sarif_file` paths to use the base name of the distribution from the `matrix.distro` variable instead of the `IMAGE_NAME` environment variable.