### PR TITLE
[Fix]: Fix workflow with trivy

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,6 +9,8 @@ env:
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+  # Set the default distribution
+  DISTRO: python
   # Versions tools
   TERRAFORM_VERSION: 1.0.0
   OC_VERSION: 4.8.0
@@ -123,6 +125,7 @@ jobs:
         id: set-args
         run: |
           echo "IMAGE_NAME=${{ github.repository }}-$(basename ${{ matrix.distro }})" >> $GITHUB_ENV
+          echo "DISTRO=$(basename ${{ matrix.distro }})" >> $GITHUB_ENV
 
       - name: Create scan directory
         run: mkdir -p scan-results
@@ -133,7 +136,7 @@ jobs:
           scan-type: "image"
           image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           format: "sarif"
-          output: "scan-results/trivy-results-$(basename ${{ matrix.distro }}).sarif"
+          output: "scan-results/trivy-results-${{ env.DISTRO }}.sarif"
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -141,4 +144,4 @@ jobs:
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3.27.6
         with:
-          sarif_file: "scan-results/trivy-results-$(basename ${{ matrix.distro }}).sarif"
+          sarif_file: "scan-results/trivy-results-${{ env.DISTRO }}.sarif"


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow file `.github/workflows/build-images.yml` to introduce a new environment variable for the distribution type and simplify the usage of this variable throughout the workflow. The most important changes include setting the default distribution, updating job steps to use this new variable, and modifying the output paths for scan results.

Environment variable addition:

* [`.github/workflows/build-images.yml`](diffhunk://#diff-a6ce9b5b0a53d8dc6dbd59d40b23994c3e68a91fac73c0d7eacdf373c95476c9R12-R13): Added a new environment variable `DISTRO` with the default value set to `python`.

Job steps updates:

* [`.github/workflows/build-images.yml`](diffhunk://#diff-a6ce9b5b0a53d8dc6dbd59d40b23994c3e68a91fac73c0d7eacdf373c95476c9R128): Updated the `set-args` job step to include the `DISTRO` environment variable.

Output path modifications:

* [`.github/workflows/build-images.yml`](diffhunk://#diff-a6ce9b5b0a53d8dc6dbd59d40b23994c3e68a91fac73c0d7eacdf373c95476c9L136-R147): Changed the `output` and `sarif_file` paths in the scan-related job steps to use the `DISTRO` environment variable instead of `matrix.distro`.