### PR TITLE
[Fix]: Extract trivy scan to another workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,8 +9,6 @@ env:
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-  # Set the default distribution
-  DISTRO: python
   # Versions tools
   TERRAFORM_VERSION: 1.0.0
   OC_VERSION: 4.8.0
@@ -104,44 +102,3 @@ jobs:
             OC_VERSION=${{ env.OC_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  scan_security:
-    needs: [build, prepare]
-    if: ${{ needs.build.result == 'success' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-    strategy:
-      matrix:
-        distro: ${{ fromJson(needs.prepare.outputs.distributions) }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4.2.2
-
-      - name: Set arguments for the build
-        id: set-args
-        run: |
-          echo "IMAGE_NAME=${{ github.repository }}-$(basename ${{ matrix.distro }})" >> $GITHUB_ENV
-          echo "DISTRO=$(basename ${{ matrix.distro }})" >> $GITHUB_ENV
-
-      - name: Create scan directory
-        run: mkdir -p scan-results
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
-        with:
-          scan-type: "image"
-          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-          format: "sarif"
-          output: "scan-results/trivy-results-${{ env.DISTRO }}.sarif"
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-
-      - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3.27.6
-        with:
-          sarif_file: "scan-results/trivy-results-${{ env.DISTRO }}.sarif"

--- a/.github/workflows/check_images.yml
+++ b/.github/workflows/check_images.yml
@@ -156,6 +156,7 @@ jobs:
             org.opencontainers.image.ref.name=${{ github.ref }}
           tags: |
             type=ref,event=branch
+            type=sha,format=long
 
       - name: Build image for analysis
         uses: docker/build-push-action@v6.10.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,78 @@
+name: trivy
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '39 3 * * 0'
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+  actions: read
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+  # Set the default distribution
+  DISTRO: python
+  # Versions tools
+  TERRAFORM_VERSION: 1.0.0
+  OC_VERSION: 4.8.0
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      distributions: ${{ steps.set-distro.outputs.distributions }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Set distributions
+        id: set-distro
+        run: |
+          echo "distributions=$(find . -name "Dockerfile" | jq -R -s -c 'split("\n")[:-1]' | \
+          sed 's|./distribution/\([^/]*\)/Dockerfile|distribution/\1|g')" >> $GITHUB_OUTPUT
+
+  scan_security:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: ${{ fromJson(needs.prepare.outputs.distributions) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Set arguments for the build
+        id: set-args
+        run: |
+          echo "IMAGE_NAME=${{ github.repository }}-$(basename ${{ matrix.distro }})" >> $GITHUB_ENV
+          echo "DISTRO=$(basename ${{ matrix.distro }})" >> $GITHUB_ENV
+
+      - name: Create scan directory
+        run: mkdir -p scan-results
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          scan-type: "image"
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          format: "sarif"
+          output: "scan-results/trivy-results-${{ env.DISTRO }}.sarif"
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "scan-results/trivy-results-${{ env.DISTRO }}.sarif"


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflows, primarily focusing on the restructuring and enhancement of security scanning processes. The changes involve removing the security scan job from the `build-images.yml` workflow and creating a dedicated `trivy.yml` workflow for vulnerability scanning using Trivy.

Improvements to security scanning:

* [`.github/workflows/build-images.yml`](diffhunk://#diff-a6ce9b5b0a53d8dc6dbd59d40b23994c3e68a91fac73c0d7eacdf373c95476c9L107-L147): Removed the `scan_security` job, which included steps for setting arguments, creating a scan directory, running the Trivy vulnerability scanner, and uploading scan results.
* [`.github/workflows/trivy.yml`](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bR1-R78): Added a new workflow dedicated to security scanning with Trivy, including jobs for preparation and security scanning, and scheduled runs.

General workflow updates:

* [`.github/workflows/build-images.yml`](diffhunk://#diff-a6ce9b5b0a53d8dc6dbd59d40b23994c3e68a91fac73c0d7eacdf373c95476c9L12-L13): Removed the `DISTRO` environment variable.
* [`.github/workflows/check_images.yml`](diffhunk://#diff-d80b44eb392d0610fc916eb375911029c50a203e90c76ed5f28016cd4a40b5c0R159): Added a new tag type `sha` with `format=long` for image analysis.